### PR TITLE
feat(pull-request): Add support for running on forked repos

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 9117:
+/***/ 4096:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -28,7 +28,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(2087));
-const utils_1 = __nccwpck_require__(9046);
+const utils_1 = __nccwpck_require__(3468);
 /**
  * Commands
  *
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 2559:
+/***/ 9699:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -135,9 +135,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
-const command_1 = __nccwpck_require__(9117);
-const file_command_1 = __nccwpck_require__(2028);
-const utils_1 = __nccwpck_require__(9046);
+const command_1 = __nccwpck_require__(4096);
+const file_command_1 = __nccwpck_require__(8363);
+const utils_1 = __nccwpck_require__(3468);
 const os = __importStar(__nccwpck_require__(2087));
 const path = __importStar(__nccwpck_require__(5622));
 /**
@@ -401,7 +401,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 2028:
+/***/ 8363:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -432,7 +432,7 @@ exports.issueCommand = void 0;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(5747));
 const os = __importStar(__nccwpck_require__(2087));
-const utils_1 = __nccwpck_require__(9046);
+const utils_1 = __nccwpck_require__(3468);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -450,7 +450,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 9046:
+/***/ 3468:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -477,7 +477,7 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 5860:
+/***/ 9922:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -513,7 +513,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getExecOutput = exports.exec = void 0;
 const string_decoder_1 = __nccwpck_require__(4304);
-const tr = __importStar(__nccwpck_require__(3690));
+const tr = __importStar(__nccwpck_require__(7343));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -587,7 +587,7 @@ exports.getExecOutput = getExecOutput;
 
 /***/ }),
 
-/***/ 3690:
+/***/ 7343:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -626,8 +626,8 @@ const os = __importStar(__nccwpck_require__(2087));
 const events = __importStar(__nccwpck_require__(8614));
 const child = __importStar(__nccwpck_require__(3129));
 const path = __importStar(__nccwpck_require__(5622));
-const io = __importStar(__nccwpck_require__(942));
-const ioUtil = __importStar(__nccwpck_require__(7061));
+const io = __importStar(__nccwpck_require__(4006));
+const ioUtil = __importStar(__nccwpck_require__(16));
 const timers_1 = __nccwpck_require__(8213);
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
@@ -1212,7 +1212,7 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 7061:
+/***/ 16:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1396,7 +1396,7 @@ exports.getCmdPath = getCmdPath;
 
 /***/ }),
 
-/***/ 942:
+/***/ 4006:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1435,7 +1435,7 @@ const assert_1 = __nccwpck_require__(2357);
 const childProcess = __importStar(__nccwpck_require__(3129));
 const path = __importStar(__nccwpck_require__(5622));
 const util_1 = __nccwpck_require__(1669);
-const ioUtil = __importStar(__nccwpck_require__(7061));
+const ioUtil = __importStar(__nccwpck_require__(16));
 const exec = util_1.promisify(childProcess.exec);
 const execFile = util_1.promisify(childProcess.execFile);
 /**
@@ -1744,7 +1744,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 9519:
+/***/ 1581:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1753,12 +1753,12 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-__export(__nccwpck_require__(2080));
+__export(__nccwpck_require__(5502));
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 2080:
+/***/ 5502:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -1768,7 +1768,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const fs_1 = __nccwpck_require__(5747);
-const debug_1 = __importDefault(__nccwpck_require__(4278));
+const debug_1 = __importDefault(__nccwpck_require__(1933));
 const log = debug_1.default('@kwsites/file-exists');
 function check(path, isFile, isDirectory) {
     log(`checking %s`, path);
@@ -1820,7 +1820,7 @@ exports.READABLE = exports.FILE + exports.FOLDER;
 
 /***/ }),
 
-/***/ 5292:
+/***/ 5770:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1886,7 +1886,7 @@ exports.default = deferred;
 
 /***/ }),
 
-/***/ 4391:
+/***/ 9411:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /* eslint-env browser */
@@ -2143,7 +2143,7 @@ function localstorage() {
 	}
 }
 
-module.exports = __nccwpck_require__(7978)(exports);
+module.exports = __nccwpck_require__(3008)(exports);
 
 const {formatters} = module.exports;
 
@@ -2162,7 +2162,7 @@ formatters.j = function (v) {
 
 /***/ }),
 
-/***/ 7978:
+/***/ 3008:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
@@ -2178,7 +2178,7 @@ function setup(env) {
 	createDebug.disable = disable;
 	createDebug.enable = enable;
 	createDebug.enabled = enabled;
-	createDebug.humanize = __nccwpck_require__(5522);
+	createDebug.humanize = __nccwpck_require__(6975);
 	createDebug.destroy = destroy;
 
 	Object.keys(env).forEach(key => {
@@ -2430,7 +2430,7 @@ module.exports = setup;
 
 /***/ }),
 
-/***/ 4278:
+/***/ 1933:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 /**
@@ -2439,15 +2439,15 @@ module.exports = setup;
  */
 
 if (typeof process === 'undefined' || process.type === 'renderer' || process.browser === true || process.__nwjs) {
-	module.exports = __nccwpck_require__(4391);
+	module.exports = __nccwpck_require__(9411);
 } else {
-	module.exports = __nccwpck_require__(4248);
+	module.exports = __nccwpck_require__(6974);
 }
 
 
 /***/ }),
 
-/***/ 4248:
+/***/ 6974:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 /**
@@ -2481,7 +2481,7 @@ exports.colors = [6, 2, 3, 4, 5, 1];
 try {
 	// Optional dependency (as in, doesn't need to be installed, NOT like optionalDependencies in package.json)
 	// eslint-disable-next-line import/no-extraneous-dependencies
-	const supportsColor = __nccwpck_require__(3645);
+	const supportsColor = __nccwpck_require__(3081);
 
 	if (supportsColor && (supportsColor.stderr || supportsColor).level >= 2) {
 		exports.colors = [
@@ -2689,7 +2689,7 @@ function init(debug) {
 	}
 }
 
-module.exports = __nccwpck_require__(7978)(exports);
+module.exports = __nccwpck_require__(3008)(exports);
 
 const {formatters} = module.exports;
 
@@ -2717,23 +2717,7 @@ formatters.O = function (v) {
 
 /***/ }),
 
-/***/ 8012:
-/***/ ((module) => {
-
-"use strict";
-
-
-module.exports = (flag, argv = process.argv) => {
-	const prefix = flag.startsWith('-') ? '' : (flag.length === 1 ? '-' : '--');
-	const position = argv.indexOf(prefix + flag);
-	const terminatorPosition = argv.indexOf('--');
-	return position !== -1 && (terminatorPosition === -1 || position < terminatorPosition);
-};
-
-
-/***/ }),
-
-/***/ 5522:
+/***/ 6975:
 /***/ ((module) => {
 
 /**
@@ -2902,15 +2886,15 @@ function plural(ms, msAbs, n, name) {
 
 /***/ }),
 
-/***/ 9791:
+/***/ 5173:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const {GitExecutor} = __nccwpck_require__(1524);
-const {SimpleGitApi} = __nccwpck_require__(7253);
+const {GitExecutor} = __nccwpck_require__(4953);
+const {SimpleGitApi} = __nccwpck_require__(1199);
 
-const {Scheduler} = __nccwpck_require__(5393);
-const {GitLogger} = __nccwpck_require__(8437);
-const {configurationErrorTask} = __nccwpck_require__(5411);
+const {Scheduler} = __nccwpck_require__(541);
+const {GitLogger} = __nccwpck_require__(7198);
+const {configurationErrorTask} = __nccwpck_require__(6272);
 const {
    asArray,
    filterArray,
@@ -2921,31 +2905,31 @@ const {
    getTrailingOptions,
    trailingFunctionArgument,
    trailingOptionsArgument
-} = __nccwpck_require__(9915);
-const {applyPatchTask} = __nccwpck_require__(9795)
-const {branchTask, branchLocalTask, deleteBranchesTask, deleteBranchTask} = __nccwpck_require__(1807);
-const {checkIgnoreTask} = __nccwpck_require__(3288);
-const {checkIsRepoTask} = __nccwpck_require__(2316);
-const {cloneTask, cloneMirrorTask} = __nccwpck_require__(3166);
-const {addConfigTask, listConfigTask} = __nccwpck_require__(4580);
-const {cleanWithOptionsTask, isCleanOptionsArray} = __nccwpck_require__(5763);
-const {commitTask} = __nccwpck_require__(5830);
-const {diffSummaryTask} = __nccwpck_require__(1874);
-const {fetchTask} = __nccwpck_require__(2936);
-const {hashObjectTask} = __nccwpck_require__(133);
-const {initTask} = __nccwpck_require__(5654);
-const {logTask, parseLogOptions} = __nccwpck_require__(275);
-const {mergeTask} = __nccwpck_require__(3001);
-const {moveTask} = __nccwpck_require__(4074);
-const {pullTask} = __nccwpck_require__(254);
-const {pushTagsTask} = __nccwpck_require__(859);
-const {addRemoteTask, getRemotesTask, listRemotesTask, remoteTask, removeRemoteTask} = __nccwpck_require__(8113);
-const {getResetMode, resetTask} = __nccwpck_require__(7166);
-const {stashListTask} = __nccwpck_require__(6304);
-const {statusTask} = __nccwpck_require__(1929);
-const {addSubModuleTask, initSubModuleTask, subModuleTask, updateSubModuleTask} = __nccwpck_require__(6641);
-const {addAnnotatedTagTask, addTagTask, tagListTask} = __nccwpck_require__(7604);
-const {straightThroughBufferTask, straightThroughStringTask} = __nccwpck_require__(5411);
+} = __nccwpck_require__(7593);
+const {applyPatchTask} = __nccwpck_require__(1565)
+const {branchTask, branchLocalTask, deleteBranchesTask, deleteBranchTask} = __nccwpck_require__(4392);
+const {checkIgnoreTask} = __nccwpck_require__(1692);
+const {checkIsRepoTask} = __nccwpck_require__(6479);
+const {cloneTask, cloneMirrorTask} = __nccwpck_require__(5690);
+const {addConfigTask, listConfigTask} = __nccwpck_require__(3812);
+const {cleanWithOptionsTask, isCleanOptionsArray} = __nccwpck_require__(8136);
+const {commitTask} = __nccwpck_require__(8922);
+const {diffSummaryTask} = __nccwpck_require__(8797);
+const {fetchTask} = __nccwpck_require__(7369);
+const {hashObjectTask} = __nccwpck_require__(7631);
+const {initTask} = __nccwpck_require__(7941);
+const {logTask, parseLogOptions} = __nccwpck_require__(3359);
+const {mergeTask} = __nccwpck_require__(8934);
+const {moveTask} = __nccwpck_require__(9392);
+const {pullTask} = __nccwpck_require__(3256);
+const {pushTagsTask} = __nccwpck_require__(6903);
+const {addRemoteTask, getRemotesTask, listRemotesTask, remoteTask, removeRemoteTask} = __nccwpck_require__(5586);
+const {getResetMode, resetTask} = __nccwpck_require__(4456);
+const {stashListTask} = __nccwpck_require__(4165);
+const {statusTask} = __nccwpck_require__(1483);
+const {addSubModuleTask, initSubModuleTask, subModuleTask, updateSubModuleTask} = __nccwpck_require__(2191);
+const {addAnnotatedTagTask, addTagTask, tagListTask} = __nccwpck_require__(3269);
+const {straightThroughBufferTask, straightThroughStringTask} = __nccwpck_require__(6272);
 
 function Git (options, plugins) {
    this._executor = new GitExecutor(
@@ -3676,12 +3660,12 @@ module.exports = Git;
 
 /***/ }),
 
-/***/ 7033:
+/***/ 5714:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 
-const {gitP} = __nccwpck_require__(3799);
-const {esModuleFactory, gitInstanceFactory, gitExportFactory} = __nccwpck_require__(4315);
+const {gitP} = __nccwpck_require__(8738);
+const {esModuleFactory, gitInstanceFactory, gitExportFactory} = __nccwpck_require__(1295);
 
 module.exports = esModuleFactory(
    gitExportFactory(gitInstanceFactory, {gitP})
@@ -3690,20 +3674,20 @@ module.exports = esModuleFactory(
 
 /***/ }),
 
-/***/ 4362:
+/***/ 4098:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const git_construct_error_1 = __nccwpck_require__(4000);
-const git_error_1 = __nccwpck_require__(8160);
-const git_plugin_error_1 = __nccwpck_require__(779);
-const git_response_error_1 = __nccwpck_require__(3876);
-const task_configuration_error_1 = __nccwpck_require__(605);
-const check_is_repo_1 = __nccwpck_require__(2316);
-const clean_1 = __nccwpck_require__(5763);
-const reset_1 = __nccwpck_require__(7166);
+const git_construct_error_1 = __nccwpck_require__(2812);
+const git_error_1 = __nccwpck_require__(6949);
+const git_plugin_error_1 = __nccwpck_require__(3331);
+const git_response_error_1 = __nccwpck_require__(2658);
+const task_configuration_error_1 = __nccwpck_require__(2070);
+const check_is_repo_1 = __nccwpck_require__(6479);
+const clean_1 = __nccwpck_require__(8136);
+const reset_1 = __nccwpck_require__(4456);
 const api = {
     CheckRepoActions: check_is_repo_1.CheckRepoActions,
     CleanOptions: clean_1.CleanOptions,
@@ -3719,14 +3703,14 @@ exports.default = api;
 
 /***/ }),
 
-/***/ 4000:
+/***/ 2812:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GitConstructError = void 0;
-const git_error_1 = __nccwpck_require__(8160);
+const git_error_1 = __nccwpck_require__(6949);
 /**
  * The `GitConstructError` is thrown when an error occurs in the constructor
  * of the `simple-git` instance itself. Most commonly as a result of using
@@ -3747,7 +3731,7 @@ exports.GitConstructError = GitConstructError;
 
 /***/ }),
 
-/***/ 8160:
+/***/ 6949:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -3791,14 +3775,14 @@ exports.GitError = GitError;
 
 /***/ }),
 
-/***/ 779:
+/***/ 3331:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GitPluginError = void 0;
-const git_error_1 = __nccwpck_require__(8160);
+const git_error_1 = __nccwpck_require__(6949);
 class GitPluginError extends git_error_1.GitError {
     constructor(task, plugin, message) {
         super(task, message);
@@ -3812,14 +3796,14 @@ exports.GitPluginError = GitPluginError;
 
 /***/ }),
 
-/***/ 3876:
+/***/ 2658:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GitResponseError = void 0;
-const git_error_1 = __nccwpck_require__(8160);
+const git_error_1 = __nccwpck_require__(6949);
 /**
  * The `GitResponseError` is the wrapper for a parsed response that is treated as
  * a fatal error, for example attempting a `merge` can leave the repo in a corrupted
@@ -3855,14 +3839,14 @@ exports.GitResponseError = GitResponseError;
 
 /***/ }),
 
-/***/ 605:
+/***/ 2070:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TaskConfigurationError = void 0;
-const git_error_1 = __nccwpck_require__(8160);
+const git_error_1 = __nccwpck_require__(6949);
 /**
  * The `TaskConfigurationError` is thrown when a command was incorrectly
  * configured. An error of this kind means that no attempt was made to
@@ -3881,17 +3865,17 @@ exports.TaskConfigurationError = TaskConfigurationError;
 
 /***/ }),
 
-/***/ 4315:
+/***/ 1295:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.gitInstanceFactory = exports.gitExportFactory = exports.esModuleFactory = void 0;
-const api_1 = __nccwpck_require__(4362);
-const plugins_1 = __nccwpck_require__(6830);
-const utils_1 = __nccwpck_require__(9915);
-const Git = __nccwpck_require__(9791);
+const api_1 = __nccwpck_require__(4098);
+const plugins_1 = __nccwpck_require__(5577);
+const utils_1 = __nccwpck_require__(7593);
+const Git = __nccwpck_require__(5173);
 /**
  * Adds the necessary properties to the supplied object to enable it for use as
  * the default export of a module.
@@ -3932,15 +3916,15 @@ exports.gitInstanceFactory = gitInstanceFactory;
 
 /***/ }),
 
-/***/ 8437:
+/***/ 7198:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GitLogger = exports.createLogger = void 0;
-const debug_1 = __nccwpck_require__(4278);
-const utils_1 = __nccwpck_require__(9915);
+const debug_1 = __nccwpck_require__(1933);
+const utils_1 = __nccwpck_require__(7593);
 debug_1.default.formatters.L = (value) => String(utils_1.filterHasLength(value) ? value.length : '-');
 debug_1.default.formatters.B = (value) => {
     if (Buffer.isBuffer(value)) {
@@ -4040,15 +4024,15 @@ exports.GitLogger = GitLogger;
 
 /***/ }),
 
-/***/ 3520:
+/***/ 8732:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hasBranchDeletionError = exports.parseBranchDeletions = void 0;
-const BranchDeleteSummary_1 = __nccwpck_require__(2631);
-const utils_1 = __nccwpck_require__(9915);
+const BranchDeleteSummary_1 = __nccwpck_require__(4791);
+const utils_1 = __nccwpck_require__(7593);
 const deleteSuccessRegex = /(\S+)\s+\(\S+\s([^)]+)\)/;
 const deleteErrorRegex = /^error[^']+'([^']+)'/m;
 const parsers = [
@@ -4076,15 +4060,15 @@ exports.hasBranchDeletionError = hasBranchDeletionError;
 
 /***/ }),
 
-/***/ 5404:
+/***/ 515:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseBranchSummary = void 0;
-const BranchSummary_1 = __nccwpck_require__(1673);
-const utils_1 = __nccwpck_require__(9915);
+const BranchSummary_1 = __nccwpck_require__(1707);
+const utils_1 = __nccwpck_require__(7593);
 const parsers = [
     new utils_1.LineParser(/^(\*\s)?\((?:HEAD )?detached (?:from|at) (\S+)\)\s+([a-z0-9]+)\s(.*)$/, (result, [current, name, commit, label]) => {
         result.push(!!current, true, name, commit, label);
@@ -4101,14 +4085,14 @@ exports.parseBranchSummary = parseBranchSummary;
 
 /***/ }),
 
-/***/ 5635:
+/***/ 5470:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseCommitResult = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 const parsers = [
     new utils_1.LineParser(/\[([^\s]+)( \([^)]+\))? ([^\]]+)/, (result, [branch, root, commit]) => {
         result.branch = branch;
@@ -4161,14 +4145,14 @@ exports.parseCommitResult = parseCommitResult;
 
 /***/ }),
 
-/***/ 4729:
+/***/ 4746:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseDiffResult = void 0;
-const DiffSummary_1 = __nccwpck_require__(567);
+const DiffSummary_1 = __nccwpck_require__(9390);
 function parseDiffResult(stdOut) {
     const lines = stdOut.trim().split('\n');
     const status = new DiffSummary_1.DiffSummary();
@@ -4242,14 +4226,14 @@ function binaryFileChange(input, { files }) {
 
 /***/ }),
 
-/***/ 4654:
+/***/ 8593:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseFetchResult = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 const parsers = [
     new utils_1.LineParser(/From (.+)$/, (result, [remote]) => {
         result.remote = remote;
@@ -4281,15 +4265,15 @@ exports.parseFetchResult = parseFetchResult;
 
 /***/ }),
 
-/***/ 9864:
+/***/ 1755:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.createListLogSummaryParser = exports.SPLITTER = exports.COMMIT_BOUNDARY = exports.START_BOUNDARY = void 0;
-const utils_1 = __nccwpck_require__(9915);
-const parse_diff_summary_1 = __nccwpck_require__(4729);
+const utils_1 = __nccwpck_require__(7593);
+const parse_diff_summary_1 = __nccwpck_require__(4746);
 exports.START_BOUNDARY = 'òòòòòò ';
 exports.COMMIT_BOUNDARY = ' òò';
 exports.SPLITTER = ' ò ';
@@ -4323,16 +4307,16 @@ exports.createListLogSummaryParser = createListLogSummaryParser;
 
 /***/ }),
 
-/***/ 8783:
+/***/ 7093:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseMergeDetail = exports.parseMergeResult = void 0;
-const MergeSummary_1 = __nccwpck_require__(6448);
-const utils_1 = __nccwpck_require__(9915);
-const parse_pull_1 = __nccwpck_require__(3512);
+const MergeSummary_1 = __nccwpck_require__(9794);
+const utils_1 = __nccwpck_require__(7593);
+const parse_pull_1 = __nccwpck_require__(3098);
 const parsers = [
     new utils_1.LineParser(/^Auto-merging\s+(.+)$/, (summary, [autoMerge]) => {
         summary.merges.push(autoMerge);
@@ -4369,14 +4353,14 @@ exports.parseMergeDetail = parseMergeDetail;
 
 /***/ }),
 
-/***/ 6023:
+/***/ 4976:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseMoveResult = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 const parsers = [
     new utils_1.LineParser(/^Renaming (.+) to (.+)$/, (result, [from, to]) => {
         result.moves.push({ from, to });
@@ -4390,16 +4374,16 @@ exports.parseMoveResult = parseMoveResult;
 
 /***/ }),
 
-/***/ 3512:
+/***/ 3098:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parsePullResult = exports.parsePullDetail = void 0;
-const PullSummary_1 = __nccwpck_require__(5493);
-const utils_1 = __nccwpck_require__(9915);
-const parse_remote_messages_1 = __nccwpck_require__(7571);
+const PullSummary_1 = __nccwpck_require__(2291);
+const utils_1 = __nccwpck_require__(7593);
+const parse_remote_messages_1 = __nccwpck_require__(9720);
 const FILE_UPDATE_REGEX = /^\s*(.+?)\s+\|\s+\d+\s*(\+*)(-*)/;
 const SUMMARY_REGEX = /(\d+)\D+((\d+)\D+\(\+\))?(\D+(\d+)\D+\(-\))?/;
 const ACTION_REGEX = /^(create|delete) mode \d+ (.+)/;
@@ -4439,15 +4423,15 @@ exports.parsePullResult = parsePullResult;
 
 /***/ }),
 
-/***/ 8000:
+/***/ 1206:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parsePushDetail = exports.parsePushResult = void 0;
-const utils_1 = __nccwpck_require__(9915);
-const parse_remote_messages_1 = __nccwpck_require__(7571);
+const utils_1 = __nccwpck_require__(7593);
+const parse_remote_messages_1 = __nccwpck_require__(9720);
 function pushResultPushedItem(local, remote, status) {
     const deleted = status.includes('deleted');
     const tag = status.includes('tag') || /^refs\/tags/.test(local);
@@ -4504,15 +4488,15 @@ exports.parsePushDetail = parsePushDetail;
 
 /***/ }),
 
-/***/ 7571:
+/***/ 9720:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RemoteMessageSummary = exports.parseRemoteMessages = void 0;
-const utils_1 = __nccwpck_require__(9915);
-const parse_remote_objects_1 = __nccwpck_require__(5432);
+const utils_1 = __nccwpck_require__(7593);
+const parse_remote_objects_1 = __nccwpck_require__(3154);
 const parsers = [
     new utils_1.RemoteLineParser(/^remote:\s*(.+)$/, (result, [text]) => {
         result.remoteMessages.all.push(text.trim());
@@ -4544,14 +4528,14 @@ exports.RemoteMessageSummary = RemoteMessageSummary;
 
 /***/ }),
 
-/***/ 5432:
+/***/ 3154:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.remoteMessagesObjectParsers = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 function objectEnumerationResult(remoteMessages) {
     return (remoteMessages.objects = remoteMessages.objects || {
         compressing: 0,
@@ -4592,14 +4576,14 @@ exports.remoteMessagesObjectParsers = [
 
 /***/ }),
 
-/***/ 9929:
+/***/ 3533:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commandConfigPrefixingPlugin = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 function commandConfigPrefixingPlugin(configuration) {
     const prefix = utils_1.prefixedArray(configuration, '-c');
     return {
@@ -4614,14 +4598,14 @@ exports.commandConfigPrefixingPlugin = commandConfigPrefixingPlugin;
 
 /***/ }),
 
-/***/ 5153:
+/***/ 532:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.errorDetectionPlugin = exports.errorDetectionHandler = void 0;
-const git_error_1 = __nccwpck_require__(8160);
+const git_error_1 = __nccwpck_require__(6949);
 function isTaskError(result) {
     return !!(result.exitCode && result.stdErr.length);
 }
@@ -4660,7 +4644,7 @@ exports.errorDetectionPlugin = errorDetectionPlugin;
 
 /***/ }),
 
-/***/ 6830:
+/***/ 5577:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -4676,25 +4660,25 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-__exportStar(__nccwpck_require__(9929), exports);
-__exportStar(__nccwpck_require__(5153), exports);
-__exportStar(__nccwpck_require__(7833), exports);
-__exportStar(__nccwpck_require__(689), exports);
-__exportStar(__nccwpck_require__(8708), exports);
-__exportStar(__nccwpck_require__(9641), exports);
-__exportStar(__nccwpck_require__(967), exports);
+__exportStar(__nccwpck_require__(3533), exports);
+__exportStar(__nccwpck_require__(532), exports);
+__exportStar(__nccwpck_require__(5346), exports);
+__exportStar(__nccwpck_require__(7167), exports);
+__exportStar(__nccwpck_require__(9874), exports);
+__exportStar(__nccwpck_require__(1903), exports);
+__exportStar(__nccwpck_require__(3482), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 7833:
+/***/ 5346:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PluginStore = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 class PluginStore {
     constructor() {
         this.plugins = new Set();
@@ -4722,14 +4706,14 @@ exports.PluginStore = PluginStore;
 
 /***/ }),
 
-/***/ 689:
+/***/ 7167:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.progressMonitorPlugin = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 function progressMonitorPlugin(progress) {
     const progressCommand = '--progress';
     const progressMethods = ['checkout', 'clone', 'fetch', 'pull', 'push'];
@@ -4774,7 +4758,7 @@ function progressEventStage(input) {
 
 /***/ }),
 
-/***/ 8708:
+/***/ 9874:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4784,14 +4768,14 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 /***/ }),
 
-/***/ 9641:
+/***/ 1903:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.spawnOptionsPlugin = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 function spawnOptionsPlugin(spawnOptions) {
     const options = utils_1.pick(spawnOptions, ['uid', 'gid']);
     return {
@@ -4806,14 +4790,14 @@ exports.spawnOptionsPlugin = spawnOptionsPlugin;
 
 /***/ }),
 
-/***/ 967:
+/***/ 3482:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.timeoutPlugin = void 0;
-const git_plugin_error_1 = __nccwpck_require__(779);
+const git_plugin_error_1 = __nccwpck_require__(3331);
 function timeoutPlugin({ block }) {
     if (block > 0) {
         return {
@@ -4850,7 +4834,7 @@ exports.timeoutPlugin = timeoutPlugin;
 
 /***/ }),
 
-/***/ 2631:
+/***/ 4791:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4888,7 +4872,7 @@ exports.isSingleBranchDeleteFailure = isSingleBranchDeleteFailure;
 
 /***/ }),
 
-/***/ 1673:
+/***/ 1707:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4921,7 +4905,7 @@ exports.BranchSummaryResult = BranchSummaryResult;
 
 /***/ }),
 
-/***/ 6302:
+/***/ 4688:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -4941,14 +4925,14 @@ exports.parseCheckIgnore = parseCheckIgnore;
 
 /***/ }),
 
-/***/ 1126:
+/***/ 1567:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.cleanSummaryParser = exports.CleanResponse = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 class CleanResponse {
     constructor(dryRun) {
         this.dryRun = dryRun;
@@ -4976,14 +4960,14 @@ exports.cleanSummaryParser = cleanSummaryParser;
 
 /***/ }),
 
-/***/ 8404:
+/***/ 8782:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.configListParser = exports.ConfigList = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 class ConfigList {
     constructor() {
         this.files = [];
@@ -5038,7 +5022,7 @@ function configFilePath(filePath) {
 
 /***/ }),
 
-/***/ 567:
+/***/ 9390:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5061,7 +5045,7 @@ exports.DiffSummary = DiffSummary;
 
 /***/ }),
 
-/***/ 1536:
+/***/ 5374:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5086,14 +5070,14 @@ exports.FileStatusSummary = FileStatusSummary;
 
 /***/ }),
 
-/***/ 4233:
+/***/ 7693:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseGetRemotesVerbose = exports.parseGetRemotes = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 function parseGetRemotes(text) {
     const remotes = {};
     forEach(text, ([name]) => remotes[name] = { name });
@@ -5123,7 +5107,7 @@ function forEach(text, handler) {
 
 /***/ }),
 
-/***/ 2922:
+/***/ 3816:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5166,7 +5150,7 @@ exports.parseInit = parseInit;
 
 /***/ }),
 
-/***/ 6448:
+/***/ 9794:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5208,7 +5192,7 @@ exports.MergeSummaryDetail = MergeSummaryDetail;
 
 /***/ }),
 
-/***/ 5493:
+/***/ 2291:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5237,15 +5221,15 @@ exports.PullSummary = PullSummary;
 
 /***/ }),
 
-/***/ 571:
+/***/ 3069:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseStatusSummary = exports.StatusSummary = void 0;
-const utils_1 = __nccwpck_require__(9915);
-const FileStatusSummary_1 = __nccwpck_require__(1536);
+const utils_1 = __nccwpck_require__(7593);
+const FileStatusSummary_1 = __nccwpck_require__(5374);
 /**
  * The StatusSummary is returned as a response to getting `git().status()`
  */
@@ -5392,7 +5376,7 @@ function splitLine(result, lineStr) {
 
 /***/ }),
 
-/***/ 7945:
+/***/ 6767:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -5455,7 +5439,7 @@ function toNumber(input) {
 
 /***/ }),
 
-/***/ 9687:
+/***/ 5874:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -5472,10 +5456,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GitExecutorChain = void 0;
 const child_process_1 = __nccwpck_require__(3129);
-const git_error_1 = __nccwpck_require__(8160);
-const task_1 = __nccwpck_require__(5411);
-const utils_1 = __nccwpck_require__(9915);
-const tasks_pending_queue_1 = __nccwpck_require__(9859);
+const git_error_1 = __nccwpck_require__(6949);
+const task_1 = __nccwpck_require__(6272);
+const utils_1 = __nccwpck_require__(7593);
+const tasks_pending_queue_1 = __nccwpck_require__(3770);
 class GitExecutorChain {
     constructor(_executor, _scheduler, _plugins) {
         this._executor = _executor;
@@ -5649,14 +5633,14 @@ function onDataReceived(target, name, logger, output) {
 
 /***/ }),
 
-/***/ 1524:
+/***/ 4953:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GitExecutor = void 0;
-const git_executor_chain_1 = __nccwpck_require__(9687);
+const git_executor_chain_1 = __nccwpck_require__(5874);
 class GitExecutor {
     constructor(binary = 'git', cwd, _scheduler, _plugins) {
         this.binary = binary;
@@ -5677,15 +5661,15 @@ exports.GitExecutor = GitExecutor;
 
 /***/ }),
 
-/***/ 3799:
+/***/ 8738:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.gitP = void 0;
-const git_response_error_1 = __nccwpck_require__(3876);
-const git_factory_1 = __nccwpck_require__(4315);
+const git_response_error_1 = __nccwpck_require__(2658);
+const git_factory_1 = __nccwpck_require__(1295);
 const functionNamesBuilderApi = [
     'customBinary', 'env', 'outputHandler', 'silent',
 ];
@@ -5817,16 +5801,16 @@ function toError(error) {
 
 /***/ }),
 
-/***/ 5393:
+/***/ 541:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Scheduler = void 0;
-const utils_1 = __nccwpck_require__(9915);
-const promise_deferred_1 = __nccwpck_require__(5292);
-const git_logger_1 = __nccwpck_require__(8437);
+const utils_1 = __nccwpck_require__(7593);
+const promise_deferred_1 = __nccwpck_require__(5770);
+const git_logger_1 = __nccwpck_require__(7198);
 const createScheduledTask = (() => {
     let id = 0;
     return () => {
@@ -5872,15 +5856,15 @@ exports.Scheduler = Scheduler;
 
 /***/ }),
 
-/***/ 9859:
+/***/ 3770:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TasksPendingQueue = void 0;
-const git_error_1 = __nccwpck_require__(8160);
-const git_logger_1 = __nccwpck_require__(8437);
+const git_error_1 = __nccwpck_require__(6949);
+const git_logger_1 = __nccwpck_require__(7198);
 class TasksPendingQueue {
     constructor(logLabel = 'GitExecutor') {
         this.logLabel = logLabel;
@@ -5943,21 +5927,21 @@ TasksPendingQueue.counter = 0;
 
 /***/ }),
 
-/***/ 7253:
+/***/ 1199:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SimpleGitApi = void 0;
-const task_callback_1 = __nccwpck_require__(51);
-const change_working_directory_1 = __nccwpck_require__(5339);
-const init_1 = __nccwpck_require__(5654);
-const merge_1 = __nccwpck_require__(3001);
-const push_1 = __nccwpck_require__(859);
-const status_1 = __nccwpck_require__(1929);
-const task_1 = __nccwpck_require__(5411);
-const utils_1 = __nccwpck_require__(9915);
+const task_callback_1 = __nccwpck_require__(1219);
+const change_working_directory_1 = __nccwpck_require__(5726);
+const init_1 = __nccwpck_require__(7941);
+const merge_1 = __nccwpck_require__(8934);
+const push_1 = __nccwpck_require__(6903);
+const status_1 = __nccwpck_require__(1483);
+const task_1 = __nccwpck_require__(6272);
+const utils_1 = __nccwpck_require__(7593);
 class SimpleGitApi {
     constructor(_executor) {
         this._executor = _executor;
@@ -6022,15 +6006,15 @@ exports.SimpleGitApi = SimpleGitApi;
 
 /***/ }),
 
-/***/ 51:
+/***/ 1219:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.taskCallback = void 0;
-const git_response_error_1 = __nccwpck_require__(3876);
-const utils_1 = __nccwpck_require__(9915);
+const git_response_error_1 = __nccwpck_require__(2658);
+const utils_1 = __nccwpck_require__(7593);
 function taskCallback(task, response, callback = utils_1.NOOP) {
     const onSuccess = (data) => {
         callback(null, data);
@@ -6071,14 +6055,14 @@ function addDeprecationNoticeToError(err) {
 
 /***/ }),
 
-/***/ 9795:
+/***/ 1565:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.applyPatchTask = void 0;
-const task_1 = __nccwpck_require__(5411);
+const task_1 = __nccwpck_require__(6272);
 function applyPatchTask(patches, customArgs) {
     return task_1.straightThroughStringTask(['apply', ...customArgs, ...patches]);
 }
@@ -6087,17 +6071,17 @@ exports.applyPatchTask = applyPatchTask;
 
 /***/ }),
 
-/***/ 1807:
+/***/ 4392:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.deleteBranchTask = exports.deleteBranchesTask = exports.branchLocalTask = exports.branchTask = exports.containsDeleteBranchCommand = void 0;
-const git_response_error_1 = __nccwpck_require__(3876);
-const parse_branch_delete_1 = __nccwpck_require__(3520);
-const parse_branch_1 = __nccwpck_require__(5404);
-const utils_1 = __nccwpck_require__(9915);
+const git_response_error_1 = __nccwpck_require__(2658);
+const parse_branch_delete_1 = __nccwpck_require__(8732);
+const parse_branch_1 = __nccwpck_require__(515);
+const utils_1 = __nccwpck_require__(7593);
 function containsDeleteBranchCommand(commands) {
     const deleteCommands = ['-d', '-D', '--delete'];
     return commands.some(command => deleteCommands.includes(command));
@@ -6170,15 +6154,15 @@ exports.deleteBranchTask = deleteBranchTask;
 
 /***/ }),
 
-/***/ 5339:
+/***/ 5726:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.changeWorkingDirectoryTask = void 0;
-const utils_1 = __nccwpck_require__(9915);
-const task_1 = __nccwpck_require__(5411);
+const utils_1 = __nccwpck_require__(7593);
+const task_1 = __nccwpck_require__(6272);
 function changeWorkingDirectoryTask(directory, root) {
     return task_1.adhocExecTask((instance) => {
         if (!utils_1.folderExists(directory)) {
@@ -6192,14 +6176,14 @@ exports.changeWorkingDirectoryTask = changeWorkingDirectoryTask;
 
 /***/ }),
 
-/***/ 3288:
+/***/ 1692:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.checkIgnoreTask = void 0;
-const CheckIgnore_1 = __nccwpck_require__(6302);
+const CheckIgnore_1 = __nccwpck_require__(4688);
 function checkIgnoreTask(paths) {
     return {
         commands: ['check-ignore', ...paths],
@@ -6212,14 +6196,14 @@ exports.checkIgnoreTask = checkIgnoreTask;
 
 /***/ }),
 
-/***/ 2316:
+/***/ 6479:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.checkIsBareRepoTask = exports.checkIsRepoRootTask = exports.checkIsRepoTask = exports.CheckRepoActions = void 0;
-const utils_1 = __nccwpck_require__(9915);
+const utils_1 = __nccwpck_require__(7593);
 var CheckRepoActions;
 (function (CheckRepoActions) {
     CheckRepoActions["BARE"] = "bare";
@@ -6280,16 +6264,16 @@ function isNotRepoMessage(error) {
 
 /***/ }),
 
-/***/ 5763:
+/***/ 8136:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isCleanOptionsArray = exports.cleanTask = exports.cleanWithOptionsTask = exports.CleanOptions = exports.CONFIG_ERROR_UNKNOWN_OPTION = exports.CONFIG_ERROR_MODE_REQUIRED = exports.CONFIG_ERROR_INTERACTIVE_MODE = void 0;
-const CleanSummary_1 = __nccwpck_require__(1126);
-const utils_1 = __nccwpck_require__(9915);
-const task_1 = __nccwpck_require__(5411);
+const CleanSummary_1 = __nccwpck_require__(1567);
+const utils_1 = __nccwpck_require__(7593);
+const task_1 = __nccwpck_require__(6272);
 exports.CONFIG_ERROR_INTERACTIVE_MODE = 'Git clean interactive mode is not supported';
 exports.CONFIG_ERROR_MODE_REQUIRED = 'Git clean mode parameter ("n" or "f") is required';
 exports.CONFIG_ERROR_UNKNOWN_OPTION = 'Git clean unknown option found in: ';
@@ -6372,15 +6356,15 @@ function isInteractiveMode(option) {
 
 /***/ }),
 
-/***/ 3166:
+/***/ 5690:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.cloneMirrorTask = exports.cloneTask = void 0;
-const task_1 = __nccwpck_require__(5411);
-const utils_1 = __nccwpck_require__(9915);
+const task_1 = __nccwpck_require__(6272);
+const utils_1 = __nccwpck_require__(7593);
 function cloneTask(repo, directory, customArgs) {
     const commands = ['clone', ...customArgs];
     if (typeof repo === 'string') {
@@ -6401,14 +6385,14 @@ exports.cloneMirrorTask = cloneMirrorTask;
 
 /***/ }),
 
-/***/ 5830:
+/***/ 8922:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commitTask = void 0;
-const parse_commit_1 = __nccwpck_require__(5635);
+const parse_commit_1 = __nccwpck_require__(5470);
 function commitTask(message, files, customArgs) {
     const commands = ['commit'];
     message.forEach((m) => commands.push('-m', m));
@@ -6424,14 +6408,14 @@ exports.commitTask = commitTask;
 
 /***/ }),
 
-/***/ 4580:
+/***/ 3812:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.listConfigTask = exports.addConfigTask = void 0;
-const ConfigList_1 = __nccwpck_require__(8404);
+const ConfigList_1 = __nccwpck_require__(8782);
 function addConfigTask(key, value, append = false) {
     const commands = ['config', '--local'];
     if (append) {
@@ -6461,14 +6445,14 @@ exports.listConfigTask = listConfigTask;
 
 /***/ }),
 
-/***/ 1874:
+/***/ 8797:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.diffSummaryTask = void 0;
-const parse_diff_summary_1 = __nccwpck_require__(4729);
+const parse_diff_summary_1 = __nccwpck_require__(4746);
 function diffSummaryTask(customArgs) {
     return {
         commands: ['diff', '--stat=4096', ...customArgs],
@@ -6483,14 +6467,14 @@ exports.diffSummaryTask = diffSummaryTask;
 
 /***/ }),
 
-/***/ 2936:
+/***/ 7369:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.fetchTask = void 0;
-const parse_fetch_1 = __nccwpck_require__(4654);
+const parse_fetch_1 = __nccwpck_require__(8593);
 function fetchTask(remote, branch, customArgs) {
     const commands = ['fetch', ...customArgs];
     if (remote && branch) {
@@ -6507,14 +6491,14 @@ exports.fetchTask = fetchTask;
 
 /***/ }),
 
-/***/ 133:
+/***/ 7631:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hashObjectTask = void 0;
-const task_1 = __nccwpck_require__(5411);
+const task_1 = __nccwpck_require__(6272);
 /**
  * Task used by `git.hashObject`
  */
@@ -6530,14 +6514,14 @@ exports.hashObjectTask = hashObjectTask;
 
 /***/ }),
 
-/***/ 5654:
+/***/ 7941:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.initTask = void 0;
-const InitSummary_1 = __nccwpck_require__(2922);
+const InitSummary_1 = __nccwpck_require__(3816);
 const bareCommand = '--bare';
 function hasBareCommand(command) {
     return command.includes(bareCommand);
@@ -6560,15 +6544,15 @@ exports.initTask = initTask;
 
 /***/ }),
 
-/***/ 275:
+/***/ 3359:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.logTask = exports.parseLogOptions = void 0;
-const parse_list_log_summary_1 = __nccwpck_require__(9864);
-const utils_1 = __nccwpck_require__(9915);
+const parse_list_log_summary_1 = __nccwpck_require__(1755);
+const utils_1 = __nccwpck_require__(7593);
 var excludeOptions;
 (function (excludeOptions) {
     excludeOptions[excludeOptions["--pretty"] = 0] = "--pretty";
@@ -6655,16 +6639,16 @@ exports.logTask = logTask;
 
 /***/ }),
 
-/***/ 3001:
+/***/ 8934:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.mergeTask = void 0;
-const git_response_error_1 = __nccwpck_require__(3876);
-const parse_merge_1 = __nccwpck_require__(8783);
-const task_1 = __nccwpck_require__(5411);
+const git_response_error_1 = __nccwpck_require__(2658);
+const parse_merge_1 = __nccwpck_require__(7093);
+const task_1 = __nccwpck_require__(6272);
 function mergeTask(customArgs) {
     if (!customArgs.length) {
         return task_1.configurationErrorTask('Git.merge requires at least one option');
@@ -6686,15 +6670,15 @@ exports.mergeTask = mergeTask;
 
 /***/ }),
 
-/***/ 4074:
+/***/ 9392:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.moveTask = void 0;
-const parse_move_1 = __nccwpck_require__(6023);
-const utils_1 = __nccwpck_require__(9915);
+const parse_move_1 = __nccwpck_require__(4976);
+const utils_1 = __nccwpck_require__(7593);
 function moveTask(from, to) {
     return {
         commands: ['mv', '-v', ...utils_1.asArray(from), to],
@@ -6707,14 +6691,14 @@ exports.moveTask = moveTask;
 
 /***/ }),
 
-/***/ 254:
+/***/ 3256:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pullTask = void 0;
-const parse_pull_1 = __nccwpck_require__(3512);
+const parse_pull_1 = __nccwpck_require__(3098);
 function pullTask(remote, branch, customArgs) {
     const commands = ['pull', ...customArgs];
     if (remote && branch) {
@@ -6733,15 +6717,15 @@ exports.pullTask = pullTask;
 
 /***/ }),
 
-/***/ 859:
+/***/ 6903:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pushTask = exports.pushTagsTask = void 0;
-const parse_push_1 = __nccwpck_require__(8000);
-const utils_1 = __nccwpck_require__(9915);
+const parse_push_1 = __nccwpck_require__(1206);
+const utils_1 = __nccwpck_require__(7593);
 function pushTagsTask(ref = {}, customArgs) {
     utils_1.append(customArgs, '--tags');
     return pushTask(ref, customArgs);
@@ -6769,15 +6753,15 @@ exports.pushTask = pushTask;
 
 /***/ }),
 
-/***/ 8113:
+/***/ 5586:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.removeRemoteTask = exports.remoteTask = exports.listRemotesTask = exports.getRemotesTask = exports.addRemoteTask = void 0;
-const GetRemoteSummary_1 = __nccwpck_require__(4233);
-const task_1 = __nccwpck_require__(5411);
+const GetRemoteSummary_1 = __nccwpck_require__(7693);
+const task_1 = __nccwpck_require__(6272);
 function addRemoteTask(remoteName, remoteRepo, customArgs = []) {
     return task_1.straightThroughStringTask(['remote', 'add', ...customArgs, remoteName, remoteRepo]);
 }
@@ -6818,14 +6802,14 @@ exports.removeRemoteTask = removeRemoteTask;
 
 /***/ }),
 
-/***/ 7166:
+/***/ 4456:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getResetMode = exports.resetTask = exports.ResetMode = void 0;
-const task_1 = __nccwpck_require__(5411);
+const task_1 = __nccwpck_require__(6272);
 var ResetMode;
 (function (ResetMode) {
     ResetMode["MIXED"] = "mixed";
@@ -6863,15 +6847,15 @@ function isValidResetMode(mode) {
 
 /***/ }),
 
-/***/ 6304:
+/***/ 4165:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.stashListTask = void 0;
-const parse_list_log_summary_1 = __nccwpck_require__(9864);
-const log_1 = __nccwpck_require__(275);
+const parse_list_log_summary_1 = __nccwpck_require__(1755);
+const log_1 = __nccwpck_require__(3359);
 function stashListTask(opt = {}, customArgs) {
     const options = log_1.parseLogOptions(opt);
     const parser = parse_list_log_summary_1.createListLogSummaryParser(options.splitter, options.fields);
@@ -6886,14 +6870,14 @@ exports.stashListTask = stashListTask;
 
 /***/ }),
 
-/***/ 1929:
+/***/ 1483:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.statusTask = void 0;
-const StatusSummary_1 = __nccwpck_require__(571);
+const StatusSummary_1 = __nccwpck_require__(3069);
 function statusTask(customArgs) {
     return {
         format: 'utf-8',
@@ -6908,14 +6892,14 @@ exports.statusTask = statusTask;
 
 /***/ }),
 
-/***/ 6641:
+/***/ 2191:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.updateSubModuleTask = exports.subModuleTask = exports.initSubModuleTask = exports.addSubModuleTask = void 0;
-const task_1 = __nccwpck_require__(5411);
+const task_1 = __nccwpck_require__(6272);
 function addSubModuleTask(repo, path) {
     return subModuleTask(['add', repo, path]);
 }
@@ -6940,14 +6924,14 @@ exports.updateSubModuleTask = updateSubModuleTask;
 
 /***/ }),
 
-/***/ 7604:
+/***/ 3269:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.addAnnotatedTagTask = exports.addTagTask = exports.tagListTask = void 0;
-const TagList_1 = __nccwpck_require__(7945);
+const TagList_1 = __nccwpck_require__(6767);
 /**
  * Task used by `git.tags`
  */
@@ -6992,14 +6976,14 @@ exports.addAnnotatedTagTask = addAnnotatedTagTask;
 
 /***/ }),
 
-/***/ 5411:
+/***/ 6272:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.isEmptyTask = exports.isBufferTask = exports.straightThroughBufferTask = exports.straightThroughStringTask = exports.configurationErrorTask = exports.adhocExecTask = exports.EMPTY_COMMANDS = void 0;
-const task_configuration_error_1 = __nccwpck_require__(605);
+const task_configuration_error_1 = __nccwpck_require__(2070);
 exports.EMPTY_COMMANDS = [];
 function adhocExecTask(parser) {
     return {
@@ -7051,14 +7035,14 @@ exports.isEmptyTask = isEmptyTask;
 
 /***/ }),
 
-/***/ 5639:
+/***/ 1865:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.filterHasLength = exports.filterFunction = exports.filterPlainObject = exports.filterStringOrStringArray = exports.filterStringArray = exports.filterString = exports.filterPrimitives = exports.filterArray = exports.filterType = void 0;
-const util_1 = __nccwpck_require__(8709);
+const util_1 = __nccwpck_require__(5485);
 function filterType(input, filter, def) {
     if (filter(input)) {
         return input;
@@ -7105,7 +7089,7 @@ exports.filterHasLength = filterHasLength;
 
 /***/ }),
 
-/***/ 1058:
+/***/ 8571:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7126,7 +7110,7 @@ var ExitCodes;
 
 /***/ }),
 
-/***/ 2427:
+/***/ 5020:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7147,7 +7131,7 @@ exports.GitOutputStreams = GitOutputStreams;
 
 /***/ }),
 
-/***/ 9915:
+/***/ 7593:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -7163,19 +7147,19 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-__exportStar(__nccwpck_require__(5639), exports);
-__exportStar(__nccwpck_require__(1058), exports);
-__exportStar(__nccwpck_require__(2427), exports);
-__exportStar(__nccwpck_require__(9005), exports);
-__exportStar(__nccwpck_require__(3438), exports);
-__exportStar(__nccwpck_require__(8772), exports);
-__exportStar(__nccwpck_require__(6816), exports);
-__exportStar(__nccwpck_require__(8709), exports);
+__exportStar(__nccwpck_require__(1865), exports);
+__exportStar(__nccwpck_require__(8571), exports);
+__exportStar(__nccwpck_require__(5020), exports);
+__exportStar(__nccwpck_require__(620), exports);
+__exportStar(__nccwpck_require__(1712), exports);
+__exportStar(__nccwpck_require__(5635), exports);
+__exportStar(__nccwpck_require__(9603), exports);
+__exportStar(__nccwpck_require__(5485), exports);
 //# sourceMappingURL=index.js.map
 
 /***/ }),
 
-/***/ 9005:
+/***/ 620:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7234,7 +7218,7 @@ exports.RemoteLineParser = RemoteLineParser;
 
 /***/ }),
 
-/***/ 3438:
+/***/ 1712:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -7257,15 +7241,15 @@ exports.createInstanceConfig = createInstanceConfig;
 
 /***/ }),
 
-/***/ 8772:
+/***/ 5635:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.trailingFunctionArgument = exports.trailingOptionsArgument = exports.getTrailingOptions = exports.appendTaskOptions = void 0;
-const argument_filters_1 = __nccwpck_require__(5639);
-const util_1 = __nccwpck_require__(8709);
+const argument_filters_1 = __nccwpck_require__(1865);
+const util_1 = __nccwpck_require__(5485);
 function appendTaskOptions(options, commands = []) {
     if (!argument_filters_1.filterPlainObject(options)) {
         return commands;
@@ -7322,14 +7306,14 @@ exports.trailingFunctionArgument = trailingFunctionArgument;
 
 /***/ }),
 
-/***/ 6816:
+/***/ 9603:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.parseStringResponse = exports.callTaskParser = void 0;
-const util_1 = __nccwpck_require__(8709);
+const util_1 = __nccwpck_require__(5485);
 function callTaskParser(parser, streams) {
     return parser(streams.stdOut, streams.stdErr);
 }
@@ -7353,14 +7337,14 @@ exports.parseStringResponse = parseStringResponse;
 
 /***/ }),
 
-/***/ 8709:
+/***/ 5485:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pick = exports.bufferToString = exports.prefixedArray = exports.asNumber = exports.asStringArray = exports.asArray = exports.objectToString = exports.remove = exports.including = exports.append = exports.folderExists = exports.forEachLineWithContent = exports.toLinesWithContent = exports.last = exports.first = exports.splitOn = exports.isUserFunction = exports.asFunction = exports.NOOP = void 0;
-const file_exists_1 = __nccwpck_require__(9519);
+const file_exists_1 = __nccwpck_require__(1581);
 const NOOP = () => {
 };
 exports.NOOP = NOOP;
@@ -7501,154 +7485,11 @@ exports.pick = pick;
 
 /***/ }),
 
-/***/ 3645:
+/***/ 1436:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-"use strict";
-
-const os = __nccwpck_require__(2087);
-const tty = __nccwpck_require__(3867);
-const hasFlag = __nccwpck_require__(8012);
-
-const {env} = process;
-
-let forceColor;
-if (hasFlag('no-color') ||
-	hasFlag('no-colors') ||
-	hasFlag('color=false') ||
-	hasFlag('color=never')) {
-	forceColor = 0;
-} else if (hasFlag('color') ||
-	hasFlag('colors') ||
-	hasFlag('color=true') ||
-	hasFlag('color=always')) {
-	forceColor = 1;
-}
-
-if ('FORCE_COLOR' in env) {
-	if (env.FORCE_COLOR === 'true') {
-		forceColor = 1;
-	} else if (env.FORCE_COLOR === 'false') {
-		forceColor = 0;
-	} else {
-		forceColor = env.FORCE_COLOR.length === 0 ? 1 : Math.min(parseInt(env.FORCE_COLOR, 10), 3);
-	}
-}
-
-function translateLevel(level) {
-	if (level === 0) {
-		return false;
-	}
-
-	return {
-		level,
-		hasBasic: true,
-		has256: level >= 2,
-		has16m: level >= 3
-	};
-}
-
-function supportsColor(haveStream, streamIsTTY) {
-	if (forceColor === 0) {
-		return 0;
-	}
-
-	if (hasFlag('color=16m') ||
-		hasFlag('color=full') ||
-		hasFlag('color=truecolor')) {
-		return 3;
-	}
-
-	if (hasFlag('color=256')) {
-		return 2;
-	}
-
-	if (haveStream && !streamIsTTY && forceColor === undefined) {
-		return 0;
-	}
-
-	const min = forceColor || 0;
-
-	if (env.TERM === 'dumb') {
-		return min;
-	}
-
-	if (process.platform === 'win32') {
-		// Windows 10 build 10586 is the first Windows release that supports 256 colors.
-		// Windows 10 build 14931 is the first release that supports 16m/TrueColor.
-		const osRelease = os.release().split('.');
-		if (
-			Number(osRelease[0]) >= 10 &&
-			Number(osRelease[2]) >= 10586
-		) {
-			return Number(osRelease[2]) >= 14931 ? 3 : 2;
-		}
-
-		return 1;
-	}
-
-	if ('CI' in env) {
-		if (['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI', 'GITHUB_ACTIONS', 'BUILDKITE'].some(sign => sign in env) || env.CI_NAME === 'codeship') {
-			return 1;
-		}
-
-		return min;
-	}
-
-	if ('TEAMCITY_VERSION' in env) {
-		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
-	}
-
-	if (env.COLORTERM === 'truecolor') {
-		return 3;
-	}
-
-	if ('TERM_PROGRAM' in env) {
-		const version = parseInt((env.TERM_PROGRAM_VERSION || '').split('.')[0], 10);
-
-		switch (env.TERM_PROGRAM) {
-			case 'iTerm.app':
-				return version >= 3 ? 3 : 2;
-			case 'Apple_Terminal':
-				return 2;
-			// No default
-		}
-	}
-
-	if (/-256(color)?$/i.test(env.TERM)) {
-		return 2;
-	}
-
-	if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
-		return 1;
-	}
-
-	if ('COLORTERM' in env) {
-		return 1;
-	}
-
-	return min;
-}
-
-function getSupportLevel(stream) {
-	const level = supportsColor(stream, stream && stream.isTTY);
-	return translateLevel(level);
-}
-
-module.exports = {
-	supportsColor: getSupportLevel,
-	stdout: translateLevel(supportsColor(true, tty.isatty(1))),
-	stderr: translateLevel(supportsColor(true, tty.isatty(2)))
-};
-
-
-/***/ }),
-
-/***/ 1206:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
-
-const core = __nccwpck_require__(2559);
-const exec = __nccwpck_require__(5860);
+const core = __nccwpck_require__(9699);
+const exec = __nccwpck_require__(9922);
 
 const INSIGHTS = ["lastCommitDate", "commitCountLast30Days", "createDate"];
 
@@ -7718,11 +7559,19 @@ async function run(config) {
 
 /***/ }),
 
+/***/ 3081:
+/***/ ((module) => {
+
+module.exports = eval("require")("supports-color");
+
+
+/***/ }),
+
 /***/ 2357:
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("assert");;
+module.exports = require("assert");
 
 /***/ }),
 
@@ -7730,7 +7579,7 @@ module.exports = require("assert");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("child_process");;
+module.exports = require("child_process");
 
 /***/ }),
 
@@ -7738,7 +7587,7 @@ module.exports = require("child_process");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("events");;
+module.exports = require("events");
 
 /***/ }),
 
@@ -7746,7 +7595,7 @@ module.exports = require("events");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("fs");;
+module.exports = require("fs");
 
 /***/ }),
 
@@ -7754,7 +7603,7 @@ module.exports = require("fs");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("os");;
+module.exports = require("os");
 
 /***/ }),
 
@@ -7762,7 +7611,7 @@ module.exports = require("os");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("path");;
+module.exports = require("path");
 
 /***/ }),
 
@@ -7770,7 +7619,7 @@ module.exports = require("path");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("string_decoder");;
+module.exports = require("string_decoder");
 
 /***/ }),
 
@@ -7778,7 +7627,7 @@ module.exports = require("string_decoder");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("timers");;
+module.exports = require("timers");
 
 /***/ }),
 
@@ -7786,7 +7635,7 @@ module.exports = require("timers");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("tty");;
+module.exports = require("tty");
 
 /***/ }),
 
@@ -7794,7 +7643,7 @@ module.exports = require("tty");;
 /***/ ((module) => {
 
 "use strict";
-module.exports = require("util");;
+module.exports = require("util");
 
 /***/ })
 
@@ -7833,15 +7682,17 @@ module.exports = require("util");;
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const fs = __nccwpck_require__(5747);
-const core = __nccwpck_require__(2559);
-const exec = __nccwpck_require__(5860);
-const simpleGit = __nccwpck_require__(7033);
-const insightsAction = __nccwpck_require__(1206);
+const core = __nccwpck_require__(9699);
+const exec = __nccwpck_require__(9922);
+const simpleGit = __nccwpck_require__(5714);
+const insightsAction = __nccwpck_require__(1436);
 
 /**
  * Asynchronously reads the contents of a file.
@@ -7861,6 +7712,13 @@ async function readFile(filePath) {
 
 function setupEnv() {
   core.setSecret("api_token");
+}
+
+function isPullRequestEvent(githubEventName) {
+  // We currently listen for "pull_request_target" since that will allow secrets
+  // to be passed in for forked repos, but we used to listen for "pull_request",
+  // so we keep it here for backwards compatibility.
+  return githubEventName === "pull_request" || githubEventName === "pull_request_target";
 }
 
 function getConfig() {
@@ -7883,6 +7741,11 @@ function getConfig() {
     required: false,
   });
 
+  // The origin is in the format of "<owner>/<repo>". This environment variable
+  // seems to have the correct value for both branch PRs and fork PRs (this
+  // needs to be the base repo, not the fork repo).
+  const origin = process.env.GITHUB_REPOSITORY;
+
   // UNIX convention is that command line arguments should take precedence
   // over environment variables. We're breaking from this convention below
   // because when this action runs on a pull request, we want to use the
@@ -7901,6 +7764,7 @@ function getConfig() {
     webpackConfigPath:
       webpackConfigPath === "__NULL__" ? undefined : webpackConfigPath,
     supportTypescript,
+    origin,
     githubBaseRef,
     githubRef,
     skipUpload,
@@ -7919,27 +7783,6 @@ async function checkoutHeadRef({ githubRef }) {
   await git.checkout(githubRef);
 }
 
-async function getRepoOrigin() {
-  const git = simpleGit(".");
-  const remotes = await git.getRemotes(true);
-  const maybeOrigin = remotes.filter((r) => r.name === "origin");
-  if (maybeOrigin.length !== 1) {
-    throw new Error("Unable to determine origin remote");
-  }
-
-  const originFullUrl = maybeOrigin[0].refs.fetch || maybeOrigin[0].refs.push;
-
-  // origins from github look like either `git@github.com:<owner name>/<repo name>`
-  // or https://github.com/<owner name>/<repo name>`
-  // and we only care about owner name and repo name to be able to find their
-  // records
-  const origin = originFullUrl
-    .replace("git@github.com:", "")
-    .replace("https://github.com/", "");
-  core.info(`Using github repo ${origin} for the origin`);
-  return origin;
-}
-
 async function getEventData() {
   const githubEventName = process.env.GITHUB_EVENT_NAME;
   let githubEventData = {};
@@ -7951,22 +7794,6 @@ async function getEventData() {
   }
 
   return { githubEventName, githubEventData };
-}
-
-async function runPreflight(githubEventName, githubEventData) {
-  if (githubEventName === "pull_request") {
-    const headRepoFullName = githubEventData.pull_request.head.repo.full_name;
-    const baseRepoFullName = githubEventData.pull_request.base.repo.full_name;
-
-    if (headRepoFullName !== baseRepoFullName) {
-      core.info(
-        `Pull request head repository ${headRepoFullName} differs from base repository ${baseRepoFullName}. Not running.`
-      );
-      return false;
-    }
-  }
-
-  return true;
 }
 
 async function runCodeseeMap(config) {
@@ -7987,7 +7814,7 @@ async function runCodeseeMap(config) {
 async function runCodeseeMapUpload(config, githubEventName, githubEventData) {
   const additionalArguments = config.githubRef ? ["-f", config.githubRef] : [];
 
-  if (githubEventName === "pull_request") {
+  if (isPullRequestEvent(githubEventName)) {
     additionalArguments.push("-b", config.githubBaseRef);
     additionalArguments.push("-s", githubEventData.pull_request.base.sha);
     additionalArguments.push("-p", githubEventData.number.toString());
@@ -8018,20 +7845,10 @@ async function main() {
   core.debug("CONFIG: ");
   core.debug(config);
 
-  config.origin = await core.group("Get Repo Origin", getRepoOrigin);
-
   await core.group("Checkout HEAD Ref", async () => checkoutHeadRef(config));
 
   const { githubEventName, githubEventData } = await getEventData();
-  const passedPreflight = await core.group(
-    "Check If Action Should Run",
-    async () => runPreflight(githubEventName, githubEventData)
-  );
   core.endGroup();
-
-  if (!passedPreflight) {
-    return;
-  }
 
   await core.group("Generate Map Data", async () => runCodeseeMap(config));
   if (config.skipUpload) {
@@ -8042,7 +7859,7 @@ async function main() {
     );
   }
 
-  if (githubEventName === "pull_request") {
+  if (isPullRequestEvent(githubEventName)) {
     core.info("Running on a pull request so skipping insight collection");
     return;
   }

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -116,19 +116,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 
-has-flag
-MIT
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
 ms
 MIT
 The MIT License (MIT)
@@ -176,16 +163,3 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-supports-color
-MIT
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
### What

Add support for running this action and generating PR diagrams for forked PRs.

- When checking for if it's a `pull_request` event, also check for `pull_request_target` since that's what we'll be moving to. And even though we'll stop using `pull_request` moving forward, we'll still support it for backwards compatibility.
- Remove the preflight check that made sure that the head repo and the base repo are the same. This was explicitly preventing forked repos from running, so since we now want them to run, this needed to be removed.
- For a forked repo, the `origin` remote that is set up is the forked repo, not the base repo. So since we used that to determine the repo that we needed to upload the dependency map for, it was using the wrong repo, resulting in a 404. Now, we'll just be using the value of the `GITHUB_REPOSITORY` environment variable. This is the correct value for both branch PRs and fork PRs. I also confirmed that this env is set for `pull_request` events as well.
- Not entirely sure why there are so many changes to `dist/`. My guess is in how `ncc` ran, but I don't know enough of it to determine the root cause. I've run this against PRs though and have confirmed that it runs, so it should be fine.