### PR TITLE
ENG-455: Pass the languages option when calling the map generate command.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2120,6 +2120,9 @@ async function runCodeseeMap(config, excludeLangs) {
   if (config.apiToken) {
     args.push("-a", config.apiToken);
   }
+  if (config.languages) {
+    args.push("--languages", `'${JSON.stringify(config.languages)}'`);
+  }
 
   args.push("-r", `https://github.com/${config.origin}`);
 

--- a/src/action.js
+++ b/src/action.js
@@ -182,6 +182,9 @@ async function runCodeseeMap(config, excludeLangs) {
   if (config.apiToken) {
     args.push("-a", config.apiToken);
   }
+  if (config.languages) {
+    args.push("--languages", `'${JSON.stringify(config.languages)}'`);
+  }
 
   args.push("-r", `https://github.com/${config.origin}`);
 


### PR DESCRIPTION
## What changed

The `map` command needs to know what languages are present in the repo
in order to determine whether it should run in incremental mode. Update
the invocation of this command to pass along the languages JSON data
structure generated by `detect-languages`
