### PR TITLE
Never run insights on a PR

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2219,12 +2219,14 @@ async function upload(data) {
 
 async function insights(data) {
   const { config, githubEventName } = data;
-  const insightsNeeded = await needsInsights(config);
-  if (insightsNeeded === INSIGHTS_DISABLED) {
+
+  if (isPullRequestEvent(githubEventName)) {
+    core.info("Running on a pull request so skipping insight collection");
     return;
   }
-  if (isPullRequestEvent(githubEventName) && !insightsNeeded) {
-    core.info("Running on a pull request so skipping insight collection");
+
+  const insightsNeeded = await needsInsights(config);
+  if (insightsNeeded === INSIGHTS_DISABLED) {
     return;
   }
 

--- a/src/action.js
+++ b/src/action.js
@@ -281,12 +281,14 @@ async function upload(data) {
 
 async function insights(data) {
   const { config, githubEventName } = data;
-  const insightsNeeded = await needsInsights(config);
-  if (insightsNeeded === INSIGHTS_DISABLED) {
+
+  if (isPullRequestEvent(githubEventName)) {
+    core.info("Running on a pull request so skipping insight collection");
     return;
   }
-  if (isPullRequestEvent(githubEventName) && !insightsNeeded) {
-    core.info("Running on a pull request so skipping insight collection");
+
+  const insightsNeeded = await needsInsights(config);
+  if (insightsNeeded === INSIGHTS_DISABLED) {
     return;
   }
 


### PR DESCRIPTION
We aren't fetching enough git history for the insights to be accurate, so it's important not to collect bad data